### PR TITLE
Creates route for NextJS dynamic robots.txt

### DIFF
--- a/examples/basic/app/robots.ts
+++ b/examples/basic/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const crawlableRobots: MetadataRoute.Robots = {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+  };
+  return crawlableRobots;
+}

--- a/packages/codegen/src/build/collect-public.ts
+++ b/packages/codegen/src/build/collect-public.ts
@@ -8,13 +8,23 @@ const { stat } = fse;
  * @returns A string array of all the files in the public folder
  */
 const collectPublicFiles = async () => {
+  console.log("collecting public files");
   const publicFiles = (await glob("public/**/*")).map((path) => path.slice(6));
   try {
     if ((await stat("app/favicon.ico")).isFile())
       publicFiles.push("/favicon.ico");
   } catch {
+    /*empty*/
+  }
+  //NextJS dynamic robots.txt
+  try {
+    if ((await stat("app/robots.ts")).isFile()) {
+      publicFiles.push("/robots.txt");
+    }
+  } catch {
     /* empty */
   }
+
   return publicFiles;
 };
 

--- a/packages/codegen/src/dev.ts
+++ b/packages/codegen/src/dev.ts
@@ -29,6 +29,7 @@ const watchConfig = {
     "app/**/redirect.{ts,js}",
     "public/**/*",
     "app/favicon.ico",
+    "app/robots.ts",
   ],
   "add unlink change": [
     "app/**/forward.dynamic.{ts,js}",


### PR DESCRIPTION
Dynamic NextJS robots.txt (auto generated from robots.ts) was blocked by the middleware by default. This does something similar than the favicon.ico rule, adding a "public file" route for robots.txt when robots.ts exists