### PR TITLE
[PWA-3615] add association files to public files

### DIFF
--- a/examples/basic/app/with-middleware/[theme]/[user]/middleware.ts
+++ b/examples/basic/app/with-middleware/[theme]/[user]/middleware.ts
@@ -1,7 +1,7 @@
 import { MiddlewareHandler } from "@cxnpl/next-app-middleware/runtime";
 
 const middleware: MiddlewareHandler<{ theme: string; user: string }> = (
-  req
+  req,
 ) => {
   console.log("middleware", req.params.theme, req.params.user);
 };

--- a/examples/basic/app/with-middleware/[theme]/page.tsx
+++ b/examples/basic/app/with-middleware/[theme]/page.tsx
@@ -13,10 +13,10 @@ export default function Home() {
       const match = JSON.stringify(
         new URLPattern(pattern, window.location.origin).exec(
           test,
-          window.location.origin
+          window.location.origin,
         )?.pathname,
         null,
-        2
+        2,
       );
       if (match !== result) setResult(match);
     } catch {
@@ -34,9 +34,7 @@ export default function Home() {
           type="text"
           onChange={({ target: { value } }) => setTest(value)}
         />
-        {result?.split("\n").map((item, key) => (
-          <span key={key}>{item}</span>
-        ))}
+        {result?.split("\n").map((item, key) => <span key={key}>{item}</span>)}
         <Link href="/userid">click</Link>
       </main>
     </div>

--- a/examples/basic/app/with-middleware/hosted/head.tsx
+++ b/examples/basic/app/with-middleware/hosted/head.tsx
@@ -5,5 +5,5 @@ export default function Head() {
       <meta content="width=device-width, initial-scale=1" name="viewport" />
       <link rel="icon" href="/favicon.ico" />
     </>
-  )
+  );
 }

--- a/examples/basic/app/with-middleware/hosted/layout.tsx
+++ b/examples/basic/app/with-middleware/hosted/layout.tsx
@@ -1,12 +1,12 @@
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   return (
     <html>
       <head />
       <body>{children}</body>
     </html>
-  )
+  );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cxnpl/next-app-middleware",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/packages/codegen/src/build/collect-public.ts
+++ b/packages/codegen/src/build/collect-public.ts
@@ -10,6 +10,18 @@ const { stat } = fse;
 const collectPublicFiles = async () => {
   console.log("collecting public files");
   const publicFiles = (await glob("public/**/*")).map((path) => path.slice(6));
+  // Association files live under .well-known/, which glob skips by default.
+  for (const wellKnownFile of [
+    "/.well-known/assetlinks.json",
+    "/.well-known/apple-app-site-association",
+  ]) {
+    try {
+      if ((await stat(`public${wellKnownFile}`)).isFile())
+        publicFiles.push(wellKnownFile);
+    } catch {
+      /*empty*/
+    }
+  }
   try {
     if ((await stat("app/favicon.ico")).isFile())
       publicFiles.push("/favicon.ico");

--- a/packages/codegen/src/dev.ts
+++ b/packages/codegen/src/dev.ts
@@ -11,7 +11,7 @@ const buildWithCatch = async (token?: CancelToken) => {
       logger.event(
         `generated middleware in ${
           Date.now() - start
-        }ms. watching for changes...`
+        }ms. watching for changes...`,
       );
     return rewrites || [];
   } catch (e) {
@@ -52,7 +52,7 @@ const dev = async () => {
   watchAll(watchConfig, runBuild);
   watchAll({ "add unlink change": ["app/**/external.{ts,js}"] }, () => {
     logger.warn(
-      "detected change in external config... restart may be required to apply changes"
+      "detected change in external config... restart may be required to apply changes",
     );
   });
   return rewrites;

--- a/packages/codegen/src/types.ts
+++ b/packages/codegen/src/types.ts
@@ -1,7 +1,7 @@
 export type LayoutType<T> = [
   T,
   LayoutType<T> | 1 | undefined,
-  LayoutType<T> | 1 | undefined
+  LayoutType<T> | 1 | undefined,
 ];
 
 export type Forwards = {
@@ -53,12 +53,12 @@ export type RouteConfig =
 export type MergedRoute = [
   current: SegmentLayout,
   next?: MergedRoute | SegmentLayout,
-  forward?: readonly [ForwarderConfig, MergedRoute]
+  forward?: readonly [ForwarderConfig, MergedRoute],
 ];
 
 export type FlattenedRoute = [
   currentSegment: SegmentLayout,
   type: RouteConfig,
   next?: FlattenedRoute | SegmentLayout,
-  forward?: FlattenedRoute | SegmentLayout
+  forward?: FlattenedRoute | SegmentLayout,
 ];

--- a/packages/codegen/src/util/run-script.ts
+++ b/packages/codegen/src/util/run-script.ts
@@ -11,7 +11,7 @@ type WrappedModule<T = unknown> = (
   req: typeof require,
   module: unknown,
   __filename: string,
-  __dirnaname: string
+  __dirnaname: string,
 ) => T;
 
 const executeScript = <T = unknown>(src: string, location: string): T => {

--- a/packages/codegen/src/util/watch.ts
+++ b/packages/codegen/src/util/watch.ts
@@ -2,7 +2,7 @@ import { watch } from "chokidar";
 
 const watchAll = (
   config: Record<string, string[]>,
-  onTrigger: (event: string, file: string) => unknown
+  onTrigger: (event: string, file: string) => unknown,
 ) => {
   Object.entries(config).forEach(([events, files]) => {
     const watcher = watch(files, { ignoreInitial: true });

--- a/packages/next-app-middleware/README.md
+++ b/packages/next-app-middleware/README.md
@@ -347,7 +347,7 @@ export const response: ResponseHook = (finalResponse) => {
 };
 ```
 
-or 
+or
 
 ```ts
 export const response: ResponseHook = (finalResponse) => {

--- a/packages/next-app-middleware/src/index.ts
+++ b/packages/next-app-middleware/src/index.ts
@@ -6,7 +6,7 @@ export const withMiddleware =
   (
     next:
       | NextConfig
-      | ((phase: string, args: { defaultConfig: NextConfig }) => NextConfig)
+      | ((phase: string, args: { defaultConfig: NextConfig }) => NextConfig),
   ) =>
   async (phase: string, args: { defaultConfig: NextConfig }) => {
     let result: ReturnType<typeof prod>;

--- a/packages/runtime/src/router/ejected/body/branches/dynamic-forward.ts
+++ b/packages/runtime/src/router/ejected/body/branches/dynamic-forward.ts
@@ -14,7 +14,7 @@ const forward_response: string | void = await ${renderHandler(
     "forward_dynamic",
     location,
     internalPath,
-    name
+    name,
   )};
 ${renderSwitchStatement({
   statement: "forward_response",

--- a/packages/runtime/src/router/ejected/body/branches/middleware.ts
+++ b/packages/runtime/src/router/ejected/body/branches/middleware.ts
@@ -11,7 +11,7 @@ const renderMiddleware = ({
 middleware_response = await ${renderHandler(
     "middleware",
     location,
-    internalPath
+    internalPath,
   )};
 ${renderSwitchStatement({
   statement: "middleware_response",

--- a/packages/runtime/src/router/ejected/body/branches/next.ts
+++ b/packages/runtime/src/router/ejected/body/branches/next.ts
@@ -14,15 +14,15 @@ next = (final_params) =>
     .replace(/\/(\*[^/]*)\/$/gm, (match, value) => {
       return match.replace(
         value,
-        `\${(final_params.${value.slice(1)} as string[]).join("/")}`
+        `\${(final_params.${value.slice(1)} as string[]).join("/")}`,
       );
     })}\`
 `
     : internalPath !== "//" && internalPath !== externalPath
-    ? `
+      ? `
 next = "${internalPath}";
 `
-    : `
+      : `
 next = true;
 `
   ).trim();

--- a/packages/runtime/src/router/ejected/body/branches/path-swtich.ts
+++ b/packages/runtime/src/router/ejected/body/branches/path-swtich.ts
@@ -25,15 +25,15 @@ const renderPathSwitch = ({
     }),
     default: `{
       ${renderBranch(defaultCase)}${
-      catchAll
-        ? `
+        catchAll
+          ? `
         if (notFound) {
           notFound = false;
           ${renderBranch(catchAll)}
         }
       `
-        : ""
-    }break;
+          : ""
+      }break;
     }`,
   });
 };

--- a/packages/runtime/src/router/ejected/body/branches/redirect.ts
+++ b/packages/runtime/src/router/ejected/body/branches/redirect.ts
@@ -11,7 +11,7 @@ const renderRedirect = ({
 const redirect_response = await ${renderHandler(
     "redirect",
     location,
-    internalPath
+    internalPath,
   )};
 ${renderSwitchStatement({
   statement: "typeof redirect_response",

--- a/packages/runtime/src/router/ejected/body/branches/rewrite.ts
+++ b/packages/runtime/src/router/ejected/body/branches/rewrite.ts
@@ -7,7 +7,7 @@ const renderRewrite = ({ location, fallback, internalPath }: EjectedRewrite) =>
 const rewrite_response = await ${renderHandler(
     "rewrite",
     location,
-    internalPath
+    internalPath,
   )};
 ${renderSwitchStatement({
   statement: "typeof rewrite_response",

--- a/packages/runtime/src/router/ejected/body/branches/static-forward.ts
+++ b/packages/runtime/src/router/ejected/body/branches/static-forward.ts
@@ -14,7 +14,7 @@ const forward_response: boolean | void = await ${renderHandler(
     "forward_static",
     location,
     internalPath,
-    name
+    name,
   )};
 ${renderSwitchStatement({
   statement: "forward_response",

--- a/packages/runtime/src/router/ejected/body/branches/util.ts
+++ b/packages/runtime/src/router/ejected/body/branches/util.ts
@@ -4,7 +4,7 @@ export const renderHandler = (
   type: string,
   location: string,
   internalPath: string,
-  imports = "default"
+  imports = "default",
 ) =>
   `
 ${type}_${getSegmentHash(location)}.then(({

--- a/packages/runtime/src/router/ejected/head/dynamic.ts
+++ b/packages/runtime/src/router/ejected/head/dynamic.ts
@@ -18,11 +18,11 @@ ${(Object.keys(imports) as (keyof Imports)[])
       .map((location) =>
         `
     const ${type.replace(".", "_")}_${getSegmentHash(
-          location
-        )} = import("./${location}/${type}");
-  `.trim()
+      location,
+    )} = import("./${location}/${type}");
+  `.trim(),
       )
-      .join("\n")
+      .join("\n"),
   )
   .filter(Boolean)
   .join("\n")}

--- a/packages/runtime/src/router/ejected/head/hooks.ts
+++ b/packages/runtime/src/router/ejected/head/hooks.ts
@@ -11,7 +11,7 @@ const renderHooksImport = (hooks: RouterHooksConfig) => {
       .map((hook) =>
         `
     ${hook} as ${hook}Hook
-    `.trim()
+    `.trim(),
       )
       .join(",\n")}
   } from "./middleware.hooks";

--- a/packages/runtime/src/util/types.ts
+++ b/packages/runtime/src/util/types.ts
@@ -57,7 +57,7 @@ export type GenericHook<ExtraArgs extends unknown[] = []> = (
 ) => OptionalPromise<NextResponse | void>;
 
 export type ParamsHook = (
-  params: ParamType
+  params: ParamType,
 ) => OptionalPromise<ParamType | void>;
 
 export type RewriteHook = GenericHook<[destination: string]>;
@@ -78,7 +78,7 @@ export type MiddleWareHandlerResult =
 
 type BaseHandler<Param extends DefaultParam, R> = (
   req: NextMiddlewareRequest<Param>,
-  res: NextMiddlewareResponse
+  res: NextMiddlewareResponse,
 ) => OptionalPromise<R>;
 
 export type MiddlewareHandler<Param extends DefaultParam = DefaultParam> =


### PR DESCRIPTION
Enabling association files in `public/.well-known` to be exempted from the middleware.

Currently it only scans for files in non-hidden folders - explicitly adding `assetlink.json` and `apple-app-site-association`. These are two standardised files for Android App Links and Apple Universal Links respectively.